### PR TITLE
Support Laravel 8 through 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php-version: '8.1'
+            laravel-version: '^8.0'
+            composer-version: 'v2.2'
+          - php-version: '8.5'
+            laravel-version: '^13.0'
+            composer-version: 'latest'
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer:${{ matrix.composer-version }}
+          coverage: none
+      - run: composer require --no-update "laravel/framework:${{ matrix.laravel-version }}"
+      - run: composer update --with-all-dependencies --no-interaction --prefer-dist --no-progress
+      - run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Laravel Geolocation Request
 
+[![Tests](https://github.com/Jord-JD/laravel-geolocation-request/actions/workflows/tests.yml/badge.svg)](https://github.com/Jord-JD/laravel-geolocation-request/actions/workflows/tests.yml)
+
 The Laravel Geolocation Request package provides an easy
 way to geolocate requests to their country of origin, simply
 by calling a `$request->country()` method.
@@ -12,6 +14,8 @@ run the following Composer command.
 ```bash
 composer require jord-jd/laravel-geolocation-request
 ``` 
+
+Version 3 supports Laravel 8 through Laravel 13 on PHP 8.1 and newer. Laravel 13 requires PHP 8.3 or newer.
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,13 @@
   "description": "Laravel Geolocation Request",
   "type": "library",
   "require": {
-    "php": ">=7.1",
-    "laravel/framework": "^5.6||^6.0||^7.0||^8.0",
+    "php": "^8.1",
+    "laravel/framework": "^8.0||^9.0||^10.0||^11.0||^12.0||^13.0",
     "jord-jd/php-geolocation": "^5.0",
-    "jord-jd/do-file-cache-psr-6": "^3.0"
+    "jord-jd/do-file-cache-psr-6": "^3.0||^4.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.6"
   },
   "license": "LGPL-3.0-only",
   "authors": [
@@ -20,6 +23,11 @@
       "JordJD\\LaravelGeolocationRequest\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "JordJD\\LaravelGeolocationRequest\\Tests\\": "tests/"
+    }
+  },
   "replace": {
     "divineomega/laravel-geolocation-request": "self.version"
   },
@@ -27,6 +35,5 @@
     "branch-alias": {
       "dev-master": "2.0-dev"
     }
-  },
-  "require-dev": {}
+  }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Traits/GeolocatableRequest.php
+++ b/src/Traits/GeolocatableRequest.php
@@ -37,7 +37,7 @@ trait GeolocatableRequest
 
         $cacheItemPool = new CacheItemPool();
         $cacheItemPool->changeConfig([
-            'cacheDirectory' => __DIR__.'/../../cache/',
+            'cacheDirectory' => sys_get_temp_dir().'/jord-jd-laravel-geolocation-request/',
         ]);
 
         $locator->setCache($cacheItemPool);
@@ -61,16 +61,4 @@ trait GeolocatableRequest
         return $this->getLocator()->getCountryByIP($ip);
     }
 
-    /**
-     * Overrides the custom request object ip() method to look at the active request object.
-     *
-     * This is required because Laravel's custom request objects do not appear to have
-     * access to the IP address, or in fact, any server variables.
-     *
-     * @return string|null
-     */
-    public function ip()
-    {
-        return request()->ip();
-    }
 }

--- a/tests/GeolocationRequestTest.php
+++ b/tests/GeolocationRequestTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace JordJD\LaravelGeolocationRequest\Tests;
+
+use JordJD\Countries\Country;
+use JordJD\Geolocation\Interfaces\LocationProviderInterface;
+use JordJD\LaravelGeolocationRequest\Http\Requests\GeolocationRequest;
+use PHPUnit\Framework\TestCase;
+
+class GeolocationRequestTest extends TestCase
+{
+    public function testUsesTheRequestIpWithAnInjectedProvider()
+    {
+        $request = GeolocationRequest::create('/', 'GET', [], [], [], [
+            'REMOTE_ADDR' => '203.0.113.10',
+        ]);
+        $provider = new RecordingLocationProvider();
+        $request->setLocationProvider($provider);
+
+        $country = $request->country();
+
+        $this->assertSame('203.0.113.10', $provider->ip);
+        $this->assertInstanceOf(Country::class, $country);
+        $this->assertSame('GB', $country->isoCodeAlpha2);
+    }
+
+    public function testReturnsNullWhenNoIpIsAvailable()
+    {
+        $request = new GeolocationRequest();
+
+        $this->assertNull($request->country());
+    }
+}
+
+class RecordingLocationProvider implements LocationProviderInterface
+{
+    public $ip;
+
+    public function getCountryByIP(string $ip): ?Country
+    {
+        $this->ip = $ip;
+        $country = new Country();
+        $country->isoCodeAlpha2 = 'GB';
+
+        return $country;
+    }
+}


### PR DESCRIPTION
## Summary

- support Laravel 8 through Laravel 13
- align the PHP minimum with the existing php-geolocation v5 dependency
- support the current DO File Cache PSR-6 release
- use the request instance IP instead of the global request helper
- move package cache writes out of the vendor directory
- add Laravel 8/PHP 8.1 and Laravel 13/PHP 8.5 tests

Resolves #1.

This is a major-version change because unsupported Laravel 5.6-7/PHP 7 combinations are removed from the declared compatibility range.